### PR TITLE
Allow Images without File Extensions in URLs for Watchkit

### DIFF
--- a/Sources/URLImage/ImageLoader/ImageLoader.swift
+++ b/Sources/URLImage/ImageLoader/ImageLoader.swift
@@ -201,7 +201,7 @@ final class ImageLoaderImpl: ImageLoader {
             do {
                 let localURL = try self.remoteFileCache.addFile(withRemoteURL: self.url, sourceURL: tmpURL)
 
-                if let image = UIImage(contentsOfFile: localURL.path) {
+                if let image = UIImage(data: try NSData(contentsOfFile: localURL.path) as Data) {
                     // Cache in memory
                     self.inMemoryCache.setImage(image, for: self.url)
 


### PR DESCRIPTION
Watchkit needs file extensions in urls when using 

if let image = UIImage(contentsOfFile: localURL.path) {

Instead use NSData. The Filetype will regonized correctly with it

UIImage(data: try NSData(contentsOfFile: localURL.path) as Data)