### PR TITLE
Added completion handler and moved Image(uiImage:) wrapper to onLoaded

### DIFF
--- a/Sources/URLImage/ImageLoader/ImageLoader.swift
+++ b/Sources/URLImage/ImageLoader/ImageLoader.swift
@@ -104,7 +104,7 @@ final class ImageLoaderImpl: ImageLoader {
                     // Check in-memory cache
                     if let image = self.inMemoryCache.image(for: self.url) {
                         self.transition(to: .finished) {
-                            self.didLoad?(Image(uiImage: image))
+                            self.didLoad?(image)
                         }
 
                         return
@@ -123,7 +123,7 @@ final class ImageLoaderImpl: ImageLoader {
                                 self.inMemoryCache.setImage(image, for: self.url)
 
                                 self.transition(to: .finished) {
-                                    self.didLoad?(Image(uiImage: image))
+                                    self.didLoad?(image)
                                 }
 
                                 return
@@ -206,7 +206,7 @@ final class ImageLoaderImpl: ImageLoader {
                     self.inMemoryCache.setImage(image, for: self.url)
 
                     self.transition(to: .finished) {
-                        self.didLoad?(Image(uiImage: image))
+                        self.didLoad?(image)
                         self.task = nil
                     }
                 }

--- a/Sources/URLImage/ImageLoader/ImageLoaderCompletion.swift
+++ b/Sources/URLImage/ImageLoader/ImageLoaderCompletion.swift
@@ -10,4 +10,4 @@
 import SwiftUI
 
 
-typealias ImageLoaderCompletion = (_ image: Image) -> Void
+typealias ImageLoaderCompletion = (_ image: UIImage) -> Void

--- a/Sources/URLImage/URLImage.swift
+++ b/Sources/URLImage/URLImage.swift
@@ -25,12 +25,15 @@ public struct URLImage<Placeholder> : View where Placeholder : View {
     let placeholder: Placeholder
 
     let configuration: ImageLoaderConfiguration
+    
+    let completion: ((UIImage?) -> Void)?
 
-    public init(_ url: URL, placeholder: () -> Placeholder, configuration: ImageLoaderConfiguration = ImageLoaderConfiguration()) {
+    public init(_ url: URL, placeholder: () -> Placeholder, configuration: ImageLoaderConfiguration = ImageLoaderConfiguration(), completion: ((UIImage?) -> Void)? = nil) {
         self.url = url
         self.placeholder = placeholder()
         self.configuration = configuration
         self.style = nil
+        self.completion = completion
     }
 
     public var body: some View {
@@ -61,8 +64,9 @@ public struct URLImage<Placeholder> : View where Placeholder : View {
         return ZStack {
             if image == nil {
                 URLImageLoaderView(url, placeholder: AnyView(placeholder), configuration: configuration, onLoaded: { image in
-                    self.image = image
+                    self.image = Image(uiImage: image)
                     self.previousURL = self.url
+                    self.completion?(image)
                 })
             }
 
@@ -93,11 +97,12 @@ public struct URLImage<Placeholder> : View where Placeholder : View {
 
 public extension URLImage {
 
-    fileprivate init(_ url: URL, placeholder: () -> Placeholder, configuration: ImageLoaderConfiguration, style: ImageStyle?) {
+    fileprivate init(_ url: URL, placeholder: () -> Placeholder, configuration: ImageLoaderConfiguration, style: ImageStyle?, completion: ((UIImage?) -> Void)? = nil) {
         self.url = url
         self.placeholder = placeholder()
         self.configuration = configuration
         self.style = style
+        self.completion = completion
     }
 }
 
@@ -105,11 +110,12 @@ public extension URLImage {
 @available(iOS 13.0, tvOS 13.0, *)
 public extension URLImage where Placeholder == Image {
 
-    init(_ url: URL, placeholder: Image = Image(systemName: "photo"), configuration: ImageLoaderConfiguration = ImageLoaderConfiguration()) {
+    init(_ url: URL, placeholder: Image = Image(systemName: "photo"), configuration: ImageLoaderConfiguration = ImageLoaderConfiguration(), completion: ((UIImage?) -> Void)? = nil) {
         self.url = url
         self.placeholder = placeholder
         self.configuration = configuration
         self.style = nil
+        self.completion = completion
     }
 }
 
@@ -128,7 +134,7 @@ extension URLImage {
             isAntialiased: style?.isAntialiased
         )
 
-        return URLImage(url, placeholder: { placeholder }, configuration: configuration, style: newStyle)
+        return URLImage(url, placeholder: { placeholder }, configuration: configuration, style: newStyle, completion: completion)
     }
 
     public func renderingMode(_ renderingMode: Image.TemplateRenderingMode?) -> URLImage {
@@ -139,7 +145,7 @@ extension URLImage {
             isAntialiased: style?.isAntialiased
         )
 
-        return URLImage(url, placeholder: { placeholder }, configuration: configuration, style: newStyle)
+        return URLImage(url, placeholder: { placeholder }, configuration: configuration, style: newStyle, completion: completion)
     }
 
     public func interpolation(_ interpolation: Image.Interpolation) -> URLImage {
@@ -150,7 +156,7 @@ extension URLImage {
             isAntialiased: style?.isAntialiased
         )
 
-        return URLImage(url, placeholder: { placeholder }, configuration: configuration, style: newStyle)
+        return URLImage(url, placeholder: { placeholder }, configuration: configuration, style: newStyle, completion: completion)
     }
 
     public func antialiased(_ isAntialiased: Bool) -> URLImage {
@@ -161,7 +167,7 @@ extension URLImage {
             isAntialiased: isAntialiased
         )
 
-        return URLImage(url, placeholder: { placeholder }, configuration: configuration, style: newStyle)
+        return URLImage(url, placeholder: { placeholder }, configuration: configuration, style: newStyle, completion: completion)
     }
 }
 
@@ -175,9 +181,9 @@ struct URLImageLoaderView : View {
 
     let configuration: ImageLoaderConfiguration
 
-    let onLoaded: (_ image: Image) -> Void
+    let onLoaded: (_ image: UIImage) -> Void
 
-    init(_ url: URL, placeholder: AnyView, configuration: ImageLoaderConfiguration, onLoaded: @escaping (_ image: Image) -> Void) {
+    init(_ url: URL, placeholder: AnyView, configuration: ImageLoaderConfiguration, onLoaded: @escaping (_ image: UIImage) -> Void) {
         self.url = url
         self.placeholder = placeholder
         self.configuration = configuration


### PR DESCRIPTION
I added a completion handler with a UIImage parameter so that you can perform custom operations with said UIImage (such as storing it in a variable) or updating the view to accommodate for the new image (so that you can have stuff shown only if the image is loaded).

Below is a code snippet from a [SwiftUI app](https://github.com/jacobcxdev/Radioactivity/) I made for practice, where you can see how I used the completion handler.

```swift
struct SectionView: View {
    @State private var showImageBackground = false
    var section: Section
    
    var body: some View {
        VStack {
            HStack {
                if section.imageURL.isEmpty {
                    Image(systemName: "photo")
                } else {
                    URLImage(URL(string: section.imageURL)!, placeholder: Image(systemName: "photo"), configuration: .init(useInMemoryCache: true), completion: { image in
                        self.showImageBackground = true // Update view to accommodate for image.
                        self.section.uiimage = image // Save UIImage for use later.
                    })
                        .resizable()
                        .scaledToFit()
                        .frame(width: 100)
                        .padding(section.imageBackground && showImageBackground ? 5 : 0)
                        .scaledToFit()
                        .frame(width: 100)
                        .background(section.imageBackground && showImageBackground ? Color(.white) : nil)
                        .cornerRadius(10)
                }
                VStack(alignment: .leading, spacing: 10) {
                    Text(section.title)
                        .font(.headline)
                    Text(section.description)
                        .font(.caption)
                        .foregroundColor(.secondary)
                }
                .padding()
            }
        }
    }
}
```