### PR TITLE
Allow customizing httpAdditionalHeaders

### DIFF
--- a/Sources/URLImage/ImageLoader/ImageLoaderService.swift
+++ b/Sources/URLImage/ImageLoader/ImageLoaderService.swift
@@ -26,6 +26,7 @@ final class ImageLoaderServiceImpl: ImageLoaderService {
     init(remoteFileCache: RemoteFileCacheService, imageProcessingService: ImageProcessingService) {
         let urlSessionConfiguration = URLSessionConfiguration.default.copy() as! URLSessionConfiguration
         urlSessionConfiguration.httpMaximumConnectionsPerHost = 1
+        urlSessionConfiguration.httpAdditionalHeaders = URLImageService.httpAdditionalHeaders
 
         urlSessionDelegate = URLSessionDelegateWrapper()
         urlSession = URLSession(configuration: urlSessionConfiguration, delegate: urlSessionDelegate, delegateQueue: queue)

--- a/Sources/URLImage/URLImageService.swift
+++ b/Sources/URLImage/URLImageService.swift
@@ -10,6 +10,10 @@ import Foundation
 
 public protocol URLImageServiceType {
 
+    static var httpAdditionalHeaders: [AnyHashable : Any]? { get }
+
+    static func setHttpAdditionalHeaders(_ httpAdditionalHeaders: [AnyHashable : Any]?)
+    
     var services: Services { get }
 
     var defaultExpiryTime: TimeInterval { get }
@@ -43,6 +47,12 @@ public final class URLImageService: URLImageServiceType {
     public static let shared: URLImageServiceType = URLImageService()
 
     public let services: Services
+
+    public static private(set) var httpAdditionalHeaders: [AnyHashable : Any]?
+
+    public static func setHttpAdditionalHeaders(_ httpAdditionalHeaders: [AnyHashable : Any]?) {
+        self.httpAdditionalHeaders = httpAdditionalHeaders
+    }
 
     public private(set) var defaultExpiryTime: TimeInterval = 60.0 * 60.0 * 24.0 * 7.0 // 1 week
 


### PR DESCRIPTION
For instance to change the User-Agent.

It was hard to find a good place to store the `httpAdditionalHeaders`.
At first tried in `URLImageService.shared` instance but the fact that `ImageLoaderService` is created at `init()` would make it crash, so I had to make it a `static` variable instead.

Sample usage:

`URLImageService.setHttpAdditionalHeaders(["User-Agent" : userAgent])`