### PR TITLE
Allow control of http session authentication credentials

### DIFF
--- a/Sources/URLImage/ImageLoader/Downloader/DownloadService.swift
+++ b/Sources/URLImage/ImageLoader/Downloader/DownloadService.swift
@@ -16,8 +16,9 @@ protocol DownloadService: AnyObject {
     func remove(_ handler: DownloadHandler, fromURLRequest urlRequest: URLRequest)
 
     func load(urlRequest: URLRequest, after delay: TimeInterval, expiryDate: Date?)
+    
+    func setCustomSessionCredentialsDelegate(_ customSessionCredentialsDelegate: URLSessionDelegate?)
 }
-
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
 final class DownloadServiceImpl: DownloadService {
@@ -189,6 +190,10 @@ final class DownloadServiceImpl: DownloadService {
 
             downloader.resume(after: delay)
         }
+    }
+    
+    func setCustomSessionCredentialsDelegate(_ customSessionCredentialsDelegate: URLSessionDelegate?) {
+        urlSessionDelegate.setCustomSessionCredentialsDelegate(customSessionCredentialsDelegate)
     }
 
     // MARK: Private

--- a/Sources/URLImage/ImageLoader/Downloader/DownloadService.swift
+++ b/Sources/URLImage/ImageLoader/Downloader/DownloadService.swift
@@ -16,35 +16,24 @@ protocol DownloadService: AnyObject {
     func remove(_ handler: DownloadHandler, fromURLRequest urlRequest: URLRequest)
 
     func load(urlRequest: URLRequest, after delay: TimeInterval, expiryDate: Date?)
-    
-    func setSessionDelegate(sessionDelegate: CustomURLSessionDelegate)
 }
 
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
 final class DownloadServiceImpl: DownloadService {
 
-    init(remoteFileCache: RemoteFileCacheService, customSessionDelegate: CustomURLSessionDelegate, retryCount: Int = 3) {
+    init(remoteFileCache: RemoteFileCacheService, retryCount: Int = 3) {
 
         let configuration = URLSessionConfiguration.default.copy(with: nil) as! URLSessionConfiguration
         configuration.httpMaximumConnectionsPerHost = 1
 
-        urlSessionDelegate = customSessionDelegate
+        urlSessionDelegate = URLSessionDelegateWrapper()
         urlSession = URLSession(configuration: configuration, delegate: urlSessionDelegate, delegateQueue: queue)
 
         self.remoteFileCache = remoteFileCache
-        self.retryCount = retryCount
         
-        defineDelegateCallbacks()
-    }
-    
-    func setSessionDelegate(sessionDelegate: CustomURLSessionDelegate) {
-        urlSessionDelegate = sessionDelegate
         
-        defineDelegateCallbacks()
-    }
-    
-    func defineDelegateCallbacks()  {
+
         func downloaderForTask(_ task: URLSessionTask) -> DownloadCoordinator? {
             guard let urlRequest = task.originalRequest else {
                 return nil
@@ -111,7 +100,7 @@ final class DownloadServiceImpl: DownloadService {
             let currentRetryCount = downloader.retryCount + 1
             
             guard let request = task.originalRequest,
-                downloader.isFailed && pendingHandlers.count > 0 && currentRetryCount <= self.retryCount
+                downloader.isFailed && pendingHandlers.count > 0 && currentRetryCount <= retryCount
             else {
                 return
             }
@@ -201,7 +190,7 @@ final class DownloadServiceImpl: DownloadService {
             downloader.resume(after: delay)
         }
     }
-    
+
     // MARK: Private
 
     private let queue: OperationQueue = {
@@ -213,8 +202,7 @@ final class DownloadServiceImpl: DownloadService {
     }()
 
     private let urlSession: URLSession
-    private var urlSessionDelegate: URLSessionDelegateWrapper
-    private var retryCount: Int
+    private let urlSessionDelegate: URLSessionDelegateWrapper
 
     private unowned let remoteFileCache: RemoteFileCacheService
 

--- a/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
+++ b/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSessionDownloadDelegate {
+open class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSessionDownloadDelegate {
 
     typealias FinishDownloadingCallback = (_ downloadTask: URLSessionDownloadTask, _ location: URL) -> Void
 
@@ -30,19 +30,19 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
 
     var completeCallback: CompleteCallback?
     
-    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+    public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         finishDownloadingCallback?(downloadTask, location)
     }
 
-    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+    public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
         writeDataCallback?(downloadTask, bytesWritten, totalBytesWritten, totalBytesExpectedToWrite)
     }
 
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         completeCallback?(task, error)
     }
     
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
         if let receiveResponseCallback = receiveResponseCallback {
             receiveResponseCallback(dataTask, response, completionHandler)
         }
@@ -51,13 +51,13 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
         }
     }
 
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         receiveDataCallback?(dataTask, data)
     }
 }
 
-extension URLSessionDelegateWrapper {
-    public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, 
+public class CustomURLSessionDelegate : URLSessionDelegateWrapper {
+    public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
                            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         if (challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust) {
             if (challenge.protectionSpace.host.isIpAddress()) {

--- a/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
+++ b/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
@@ -56,7 +56,12 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
     }
     
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        customSessionCredentialsDelegate?.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
+        if let customSessionCredentialsDelegate = customSessionCredentialsDelegate {
+            customSessionCredentialsDelegate.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
+        }
+        else {
+            completionHandler(.performDefaultHandling, nil)
+        }
     }
     
     func setCustomSessionCredentialsDelegate(_ customSessionCredentialsDelegate: URLSessionDelegate?) {

--- a/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
+++ b/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
@@ -54,4 +54,14 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         receiveDataCallback?(dataTask, data)
     }
+    
+    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        customSessionCredentialsDelegate?.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
+    }
+    
+    func setCustomSessionCredentialsDelegate(_ customSessionCredentialsDelegate: URLSessionDelegate?) {
+        self.customSessionCredentialsDelegate = customSessionCredentialsDelegate
+    }
+    
+    private var customSessionCredentialsDelegate: URLSessionDelegate?
 }

--- a/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
+++ b/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSessionDownloadDelegate {
 
     typealias FinishDownloadingCallback = (_ downloadTask: URLSessionDownloadTask, _ location: URL) -> Void
@@ -29,7 +28,7 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
     var receiveDataCallback: ReceiveDataCallback?
 
     var completeCallback: CompleteCallback?
-    
+
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         finishDownloadingCallback?(downloadTask, location)
     }
@@ -41,7 +40,7 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         completeCallback?(task, error)
     }
-    
+
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
         if let receiveResponseCallback = receiveResponseCallback {
             receiveResponseCallback(dataTask, response, completionHandler)
@@ -54,7 +53,7 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         receiveDataCallback?(dataTask, data)
     }
-    
+
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         if let customSessionCredentialsDelegate = customSessionCredentialsDelegate {
             customSessionCredentialsDelegate.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
@@ -63,10 +62,10 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
             completionHandler(.performDefaultHandling, nil)
         }
     }
-    
+
     func setCustomSessionCredentialsDelegate(_ customSessionCredentialsDelegate: URLSessionDelegate?) {
         self.customSessionCredentialsDelegate = customSessionCredentialsDelegate
     }
-    
+
     private var customSessionCredentialsDelegate: URLSessionDelegate?
 }

--- a/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
+++ b/Sources/URLImage/ImageLoader/Downloader/URLSessionDownloadDelegateWrapper.swift
@@ -55,3 +55,32 @@ final class URLSessionDelegateWrapper: NSObject, URLSessionDataDelegate, URLSess
         receiveDataCallback?(dataTask, data)
     }
 }
+
+extension URLSessionDelegateWrapper {
+    public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, 
+                           completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        if (challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust) {
+            if (challenge.protectionSpace.host.isIpAddress()) {
+                let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
+                completionHandler(URLSession.AuthChallengeDisposition.useCredential, credential)
+                return
+            }
+        }
+        completionHandler(.performDefaultHandling, nil)
+    }
+}
+
+extension String {
+    func isIPv4() -> Bool {
+        var sin = sockaddr_in()
+        return self.withCString({ cstring in inet_pton(AF_INET, cstring, &sin.sin_addr) }) == 1
+    }
+
+    func isIPv6() -> Bool {
+        var sin6 = sockaddr_in6()
+        return self.withCString({ cstring in inet_pton(AF_INET6, cstring, &sin6.sin6_addr) }) == 1
+    }
+
+    func isIpAddress() -> Bool { return self.isIPv6() || self.isIPv4() }
+}
+

--- a/Sources/URLImage/URLImageService.swift
+++ b/Sources/URLImage/URLImageService.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
 public protocol URLImageServiceType {
 
@@ -20,6 +19,8 @@ public protocol URLImageServiceType {
     func resetFileCache()
 
     func cleanFileCache()
+    
+    func setCustomSessionDelegate(customSessionDelegate: CustomURLSessionDelegate)
 }
 
 
@@ -45,6 +46,8 @@ public final class URLImageService: URLImageServiceType {
     public let services: Services
 
     public private(set) var defaultExpiryTime: TimeInterval = 60.0 * 60.0 * 24.0 * 7.0 // 1 week
+    
+    public private(set) var customSessionDelegate: CustomURLSessionDelegate = CustomURLSessionDelegate()
 
     public func setDefaultExpiryTime(_ defaultExpiryTime: TimeInterval) {
         self.defaultExpiryTime = defaultExpiryTime
@@ -58,9 +61,13 @@ public final class URLImageService: URLImageServiceType {
         services.remoteFileCacheService.clean()
     }
 
+    public func setCustomSessionDelegate(customSessionDelegate: CustomURLSessionDelegate) {
+        services.downloadService.setSessionDelegate(sessionDelegate: customSessionDelegate)
+    }
+    
     private init() {
         let remoteFileCacheService = RemoteFileCacheServiceImpl(name: "URLImage", baseURL: FileManager.appCachesDirectoryURL)
-        let downloadService = DownloadServiceImpl(remoteFileCache: remoteFileCacheService)
+        let downloadService = DownloadServiceImpl(remoteFileCache: remoteFileCacheService, customSessionDelegate: customSessionDelegate)
 
         services = Services(remoteFileCacheService: remoteFileCacheService, downloadService: downloadService)
     }

--- a/Sources/URLImage/URLImageService.swift
+++ b/Sources/URLImage/URLImageService.swift
@@ -20,6 +20,8 @@ public protocol URLImageServiceType {
     func resetFileCache()
 
     func cleanFileCache()
+    
+    func setCustomSessionCredentialsDelegate(_ customSessionCredentialsDelegate: URLSessionDelegate?)
 }
 
 
@@ -58,6 +60,10 @@ public final class URLImageService: URLImageServiceType {
         services.remoteFileCacheService.clean()
     }
 
+    public func setCustomSessionCredentialsDelegate(_ customSessionCredentialsDelegate: URLSessionDelegate?) {
+        services.downloadService.setCustomSessionCredentialsDelegate(customSessionCredentialsDelegate)
+    }
+    
     private init() {
         let remoteFileCacheService = RemoteFileCacheServiceImpl(name: "URLImage", baseURL: FileManager.appCachesDirectoryURL)
         let downloadService = DownloadServiceImpl(remoteFileCache: remoteFileCacheService)

--- a/Sources/URLImage/URLImageService.swift
+++ b/Sources/URLImage/URLImageService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
 public protocol URLImageServiceType {
 
@@ -19,8 +20,6 @@ public protocol URLImageServiceType {
     func resetFileCache()
 
     func cleanFileCache()
-    
-    func setCustomSessionDelegate(customSessionDelegate: CustomURLSessionDelegate)
 }
 
 
@@ -46,8 +45,6 @@ public final class URLImageService: URLImageServiceType {
     public let services: Services
 
     public private(set) var defaultExpiryTime: TimeInterval = 60.0 * 60.0 * 24.0 * 7.0 // 1 week
-    
-    public private(set) var customSessionDelegate: CustomURLSessionDelegate = CustomURLSessionDelegate()
 
     public func setDefaultExpiryTime(_ defaultExpiryTime: TimeInterval) {
         self.defaultExpiryTime = defaultExpiryTime
@@ -61,13 +58,9 @@ public final class URLImageService: URLImageServiceType {
         services.remoteFileCacheService.clean()
     }
 
-    public func setCustomSessionDelegate(customSessionDelegate: CustomURLSessionDelegate) {
-        services.downloadService.setSessionDelegate(sessionDelegate: customSessionDelegate)
-    }
-    
     private init() {
         let remoteFileCacheService = RemoteFileCacheServiceImpl(name: "URLImage", baseURL: FileManager.appCachesDirectoryURL)
-        let downloadService = DownloadServiceImpl(remoteFileCache: remoteFileCacheService, customSessionDelegate: customSessionDelegate)
+        let downloadService = DownloadServiceImpl(remoteFileCache: remoteFileCacheService)
 
         services = Services(remoteFileCacheService: remoteFileCacheService, downloadService: downloadService)
     }


### PR DESCRIPTION
To be capable of, for example, download from https + ip-address urls.

The idea of usage is:
1. Implement custom `URLSessionDelegate` somewhere in my code:
```
public class URLSessionInsecureDelegate: NSObject, URLSessionDelegate {
    public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
        if (challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust) {
            if (challenge.protectionSpace.host.isIpAddress()){
                let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
                completionHandler(URLSession.AuthChallengeDisposition.useCredential, credential)
                return
            }
        }
        completionHandler(.performDefaultHandling, nil)
    }
}
```

2. Configure `URLImageService` with this custom delegate on app start: 
```
URLImageService.shared.setCustomSessionCredentialsDelegate(URLSessionInsecureDelegate())
```

Please note, that custom delegate does not interfere with `URLSessionDataDelegate` and `URLSessionDownloadDelegate `callbacks, which are vital for proper downloading.
`URLSessionDelegateWrapper` only calls custom delegate's callback if it is set, otherwise it handles the session with default behaviour, like before.
