### PR TITLE
Possible memory leak fix

### DIFF
--- a/Dependencies/Sources/RemoteContentView/RemoteContentView.swift
+++ b/Dependencies/Sources/RemoteContentView/RemoteContentView.swift
@@ -81,7 +81,7 @@ public struct RemoteContentView<Value, Progress, Empty, InProgress, Failure, Con
 
                 case .failure(let error):
                     failure(error) {
-                        remoteContent.load()
+                        self.reload()
                     }
             }
         }
@@ -92,9 +92,13 @@ public struct RemoteContentView<Value, Progress, Empty, InProgress, Failure, Con
         }
         .onDisappear {
             if loadOptions.contains(.cancelOnDisappear) {
-                remoteContent.load()
+                remoteContent.cancel()
             }
         }
+    }
+
+    private func reload() {
+      remoteContent.load()
     }
 
     @ObservedObject private var remoteContent: AnyRemoteContent<Value, Progress>


### PR DESCRIPTION
We were getting some leaked objects of type AnyRemoteContent in our app. This PR appears to fix it with no ill effects.

I also spotted that you were loading instead of cancelling when .cancelOnDisappear was set. I assumed this was a mistake, if it was not then I can undo that change.