### PR TITLE
Add the option to animate image loading. Implements #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ Time interval after which the cached image expires and can be deleted. Images ar
 
 Maximum size of a decoded image in pixels. If this property is not specified, the width and height of a decoded is not limited and may be as big as the image itself.
 
+**`loadCachedAnimation: Animation?`**
+
+Animation to apply when the image is loaded from the cache. By default, there is no animation.
+
+**`loadFromNetworkAnimation: Animation?`**
+
+Animation to apply when the image is loaded from the network. By default, there is no animation.
+
 **`cachePolicy: CachePolicy`**
 
 The cache policy controls how the image loaded from cache.

--- a/Sources/URLImage/Model/RemoteImage.swift
+++ b/Sources/URLImage/Model/RemoteImage.swift
@@ -169,7 +169,9 @@ extension RemoteImage {
         }
 
         // Set image retrieved from cache
-        self.loadingState = .success(transientImage)
+        withAnimation(self.options.loadCachedAnimation) {
+            self.loadingState = .success(transientImage)
+        }
         log_debug(self, #function, "Image for \(download.url) is in the in memory cache", detail: log_normal)
 
         return true
@@ -251,7 +253,9 @@ extension RemoteImage {
                             let transientImage = try self.service.decode(result: result,
                                                                          download: self.download,
                                                                          options: self.options)
-                            self.updateLoadingState(.success(transientImage))
+                            withAnimation(self.options.loadFromNetworkAnimation) {
+                                self.updateLoadingState(.success(transientImage))
+                            }
                         }
                         catch {
                             // This route happens when download succeeds, but decoding fails
@@ -284,7 +288,9 @@ extension RemoteImage {
                                                                    identifier: self.options.identifier,
                                                                    expireAfter: self.options.expiryInterval)
                     // Set image retrieved from cache
-                    self.loadingState = .success(transientImage)
+                    withAnimation(self.options.loadCachedAnimation) {
+                        self.loadingState = .success(transientImage)
+                    }
                     completion(true)
                 }
                 else {

--- a/Sources/URLImage/URLImageOptions.swift
+++ b/Sources/URLImage/URLImageOptions.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreGraphics
+import SwiftUI
 
 #if canImport(DownloadManager)
 import DownloadManager
@@ -86,17 +87,27 @@ public struct URLImageOptions {
     /// Maximum size of a decoded image in pixels. If this property is not specified, the width and height of a decoded is not limited and may be as big as the image itself.
     public var maxPixelSize: CGSize?
 
+    /// Animation to apply when the image is loaded from the cache. Default: no animation
+    public var loadCachedAnimation: Animation?
+
+    /// Animation to apply when the image is loaded from a network response. Default: no animation
+    public var loadFromNetworkAnimation: Animation?
+
     public init(identifier: String? = nil,
                 expireAfter expiryInterval: TimeInterval? = URLImageService.shared.defaultOptions.expiryInterval,
                 cachePolicy: CachePolicy = URLImageService.shared.defaultOptions.cachePolicy,
                 load loadOptions: LoadOptions = URLImageService.shared.defaultOptions.loadOptions,
                 urlRequestConfiguration: Download.URLRequestConfiguration = URLImageService.shared.defaultOptions.urlRequestConfiguration,
-                maxPixelSize: CGSize? = URLImageService.shared.defaultOptions.maxPixelSize) {
+                maxPixelSize: CGSize? = URLImageService.shared.defaultOptions.maxPixelSize,
+                loadCachedAnimation: Animation? = nil,
+                loadFromNetworkAnimation: Animation? = nil) {
         self.identifier = identifier
         self.expiryInterval = expiryInterval
         self.cachePolicy = cachePolicy
         self.loadOptions = loadOptions
         self.urlRequestConfiguration = urlRequestConfiguration
         self.maxPixelSize = maxPixelSize
+        self.loadCachedAnimation = loadCachedAnimation
+        self.loadFromNetworkAnimation = loadFromNetworkAnimation
     }
 }


### PR DESCRIPTION
First of all, thank you for this awesome project! I noticed that there was no support for animations and I wanted to contribute so there is it 😄

By default, the previous behaviour is maintained, that is, no animations. Only when the new options are set the animations will be triggered. The user can decide the curve and the duration (or just use `Animation.default`), but it will always do a fade animation.

I've split the animations in two, because maybe someone wants to animate the loading of images only when they appear from the network or not.

Please let me know if I need to do any change, I'll be happy to do it!