### PR TITLE
URLImageFileStore.init(fileIndex:) now public

### DIFF
--- a/Sources/URLImageStore/URLImageFileStore.swift
+++ b/Sources/URLImageStore/URLImageFileStore.swift
@@ -18,7 +18,7 @@ public final class URLImageFileStore {
 
     let fileIndex: FileIndex
 
-    init(fileIndex: FileIndex) {
+    public init(fileIndex: FileIndex) {
         self.fileIndex = fileIndex
     }
 


### PR DESCRIPTION
This patch allows to customize path to file storage:

           ```
             let fileIndexConfiguration = FileIndex.Configuration(
                  name: "URLImage",
                  filesDirectoryName: "images",
                  directoryURL: /* OUR PATH */
            )
            let fileIndex = FileIndex( configuration: fileIndexConfiguration )

            let urlImageService = URLImageService(
                  fileStore: URLImageFileStore( fileIndex: fileIndex ), // <-- this now public, otherwise will not compile
                  inMemoryStore: URLImageInMemoryStore()
            )
```